### PR TITLE
add ability to be used as PostCSS plugin

### DIFF
--- a/index2.js
+++ b/index2.js
@@ -1,0 +1,11 @@
+var postcss = require('postcss');
+var qcss = require('./qcss-web.js');
+
+module.exports = postcss.plugin('postcss-qcss', function (options) {
+  return function (css, result) {
+    var oldCssText = css.toString();
+    var newCssText = qcss(oldCssText);
+    var newCssObj = postcss.parse(newCssText);
+    result.root = newCssObj;
+  };
+});

--- a/package.json
+++ b/package.json
@@ -26,12 +26,17 @@
   },
   "dependencies": {
     "gulp-util": "^2.2.14",
-    "through2": "^0.4.2"
+    "through2": "^0.4.2",
+    "postcss": "latest"
   },
   "devDependencies": {},
   "engines": {
     "node": ">=0.9"
   },
+  "keywords": [
+    "qcss",
+    "postcss-plugin"
+  ],
   "license": "MIT",
   "maintainers": [
     {

--- a/qcss-map.js
+++ b/qcss-map.js
@@ -92,6 +92,7 @@ module.exports = {
         bs: 'box-shadow: ',
         ts: 'text-shadow: ',
         con: 'content: ',
+        pe: 'pointer-events: ',
         table: 'display: table; table-layout: fixed; width: 100%',
         center: 'position: absolute; top: 0; bottom: 0; right: 0; left: 0; margin: auto',
         ell: 'text-overflow: ellipsis; white-space: nowrap; overflow: hidden',

--- a/qcss-web.js
+++ b/qcss-web.js
@@ -48,11 +48,11 @@ module.exports = function (data) {
             if (!state) {
                 return '';
             }
-            if (state.indexOf(':') != -1) {
-                return state;
-            }
+            // if (state.indexOf(':') != -1) {
+            //     return state;
+            // }
             // state指一段声明，例如f 20，此时下面的key是f, value是20
-            return state.replace(/^([a-z]+)(.*)$/g, function (matchs, key, value) {
+            return state.replace(/^([a-z]+):\s(.*)$/g, function (matchs, key, value) {
                 // 值主要是增加单位，和一些关键字转换
                 // 1. 逗号
                 value = (value || '').split(',').map(function (multiple) {


### PR DESCRIPTION
I have test it as a PostCss plugin, and use in our project. It's good to use. I think we can improve it better. I find some problems yet:
1. use the grammar don't have colon may can't work well with other tools like PostCss loader, so I change a little code to support normal grammar with colon. I don't test if it can be compatible with origin style, but the ability of short name of both property and value can't be used. That means, I can use `.g2 { t: 16; mb: 12; }` , but can't use `.g2 { dn; }`, the PostCss loader will report error.
2. it can't support svg as background image well, it don't transform `bgi: url("data:image/svg+xml,%3Csvg ...`, but if I use full name  `background-image: url("data:image/svg+xml,%3Csvg ...`, it can work well. 
3. in my environment, it can't transform short name in SCSS block, I'm not sure whether it's my configuration problem. I will check it later.
May  have help to you.